### PR TITLE
ci: fix flake8 max length in GH action

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -29,5 +29,5 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # exit-zero treats all errors as warnings. Line len as in project's setup.cfg
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics


### PR DESCRIPTION
Sync'ing max line length in `setup.cfg` and `.github/workflows/flake8.yml`.