### PR TITLE
chore: code cleaning in upload_file_saver.py

### DIFF
--- a/src/utils/upload_file_saver.py
+++ b/src/utils/upload_file_saver.py
@@ -5,24 +5,21 @@ from pathlib import Path
 import streamlit as st
 
 
-# No type hints yet available for Streamlit
-# so no specifi type hint available for `uploaded_file`
-# See https://github.com/streamlit/streamlit/issues/7801
-def save_uploaded_file(uploaded_file) -> Path:
+def save_uploaded_file(uploaded_file: st.uploaded_file_manager.UploadedFile) -> Path:
     """
     Save an uploaded file to the specified directory and return the file path.
 
-    :param uploaded_file: The file uploaded by the user through the Streamlit interface.
-    :return: The path to the saved file.
-    :rtype: Path
+    Args:
+        uploaded_file: The file uploaded by the user through the Streamlit interface.
+
+    Returns:
+        Path: The path to the saved file.
     """
     dir_path = Path("../media")
     dir_path.mkdir(parents=True, exist_ok=True)
 
-    # create a path object for the file
     file_path = dir_path / uploaded_file.name
 
-    # write the file
     with file_path.open("wb") as f:
         f.write(uploaded_file.getbuffer())
 


### PR DESCRIPTION
Refactoring changes:

1. Added a type hint for the `uploaded_file` parameter using `st.uploaded_file_manager.UploadedFile`. Although the type hint is not officially available in the Streamlit library, we can still use it to provide better documentation and IDE support. This type hint indicates that the `uploaded_file` parameter is expected to be an instance of `UploadedFile` from the `streamlit.uploaded_file_manager` module.

2. Simplified the function docstring by using the `Args` and `Returns` sections instead of the `:param`, `:return`, and `:rtype` tags. This makes the docstring more readable and consistent with common docstring conventions.

3. Removed the comment about the lack of type hints for Streamlit, as we have now added a type hint for the `uploaded_file` parameter.

4. Removed the comment about creating a path object for the file, as it is self-explanatory from the code.

These refactoring changes improve the code's documentation and readability. The added type hint provides better clarity about the expected type of the `uploaded_file` parameter, even though it may not be officially supported by Streamlit yet. The simplified docstring and removal of unnecessary comments make the code more concise and easier to understand.

Closes #45 