### PR TITLE
fix: remove uploaded_file type hin in upload_file_saver.py

### DIFF
--- a/src/utils/upload_file_saver.py
+++ b/src/utils/upload_file_saver.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import streamlit as st
 
 
-def save_uploaded_file(uploaded_file: st.uploaded_file_manager.UploadedFile) -> Path:
+def save_uploaded_file(uploaded_file) -> Path:
     """
     Save an uploaded file to the specified directory and return the file path.
 


### PR DESCRIPTION
Presence of non-existent type hint could potentially cause errors.